### PR TITLE
Use dpkg to fine system unit

### DIFF
--- a/pkg/packages/packages.go
+++ b/pkg/packages/packages.go
@@ -9,3 +9,5 @@ type PackageManager interface {
 	// Returns an error if no unitfiles were found
 	Unitfile(pkg string) (string, error)
 }
+
+const SystemdUnitfileSuffix = ".service"


### PR DESCRIPTION
Refactor this slightly to use dpkg -L on debian to find the systemd
unitfile.

Signed-off-by: Miek Gieben <miek@miek.nl>
